### PR TITLE
Serialize values sent with produceMany

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const p = kafka.producer()
 const res = await p.produceMany([
   {
     topic: "my.topic",
-    value: "my message",
+    value: { hello: "world" },
     // ...options
   },
   {

--- a/pkg/produce.test.ts
+++ b/pkg/produce.test.ts
@@ -29,12 +29,12 @@ it("Publish a serialized succesfully", async () => {
 it("publishes multiple messages to different topics succesfully", async () => {
   const p = kafka.producer()
   const c = kafka.consumer()
-  const message0 = { hello: "test" }
-  const message1 = { hello: "world" }
+  const message0 = "test"
+  const message1 = "world"
 
   const res = await p.produceMany([
-    { topic: Topic.RED, value: JSON.stringify(message0) },
-    { topic: Topic.GREEN, value: JSON.stringify(message1) },
+    { topic: Topic.RED, value: message0 },
+    { topic: Topic.GREEN, value: message1 },
   ])
 
   const found = await c.fetch({
@@ -45,6 +45,28 @@ it("publishes multiple messages to different topics succesfully", async () => {
     })),
   })
 
-  expect(found.map((f) => JSON.parse(f.value))).toContainEqual(message0)
-  expect(found.map((f) => JSON.parse(f.value))).toContainEqual(message1)
+  expect(found[0].value).toEqual(message0)
+  expect(found[1].value).toEqual(message1)
+})
+it("publishes multiple serialized messages to different topics succesfully", async () => {
+  const p = kafka.producer()
+  const c = kafka.consumer()
+  const message0 = { hello: "test" }
+  const message1 = { hello: "world" }
+
+  const res = await p.produceMany([
+    { topic: Topic.RED, value: message0 },
+    { topic: Topic.GREEN, value: message1 },
+  ])
+
+  const found = await c.fetch({
+    topicPartitionOffsets: res.map((r) => ({
+      topic: r.topic,
+      partition: r.partition,
+      offset: r.offset,
+    })),
+  })
+
+  expect(JSON.parse(found[0].value)).toEqual(message0)
+  expect(JSON.parse(found[1].value)).toEqual(message1)
 })

--- a/pkg/produce.test.ts
+++ b/pkg/produce.test.ts
@@ -66,7 +66,6 @@ it("publishes multiple serialized messages to different topics succesfully", asy
       offset: r.offset,
     })),
   })
-
-  expect(JSON.parse(found[0].value)).toEqual(message0)
+  expect(JSON.parse(found[0].value)).toStrictEqual(message0)
   expect(JSON.parse(found[1].value)).toEqual(message1)
 })

--- a/pkg/producer.ts
+++ b/pkg/producer.ts
@@ -83,6 +83,11 @@ export class Producer {
    * Each entry in the response array belongs to the request with the same order in the requests.
    */
   public async produceMany(requests: ProduceRequest[]): Promise<ProduceResponse[]> {
+    requests = requests.map((x) => ({
+      topic: x.topic,
+      value: typeof x.value === "string" ? x.value : JSON.stringify(x.value),
+    }))
+
     return await this.client.post<ProduceResponse[]>({
       path: ["produce"],
       body: requests,

--- a/pkg/producer.ts
+++ b/pkg/producer.ts
@@ -83,9 +83,9 @@ export class Producer {
    * Each entry in the response array belongs to the request with the same order in the requests.
    */
   public async produceMany(requests: ProduceRequest[]): Promise<ProduceResponse[]> {
-    requests = requests.map((x) => ({
-      topic: x.topic,
-      value: typeof x.value === "string" ? x.value : JSON.stringify(x.value),
+    requests = requests.map(({ topic, value }) => ({
+      topic,
+      value: typeof value === "string" ? value : JSON.stringify(value),
     }))
 
     return await this.client.post<ProduceResponse[]>({


### PR DESCRIPTION
As mentioned on Discord. :D

This may not be a bug and expected behavior. As the code specifies at https://github.com/upstash/upstash-kafka#produce-a-single-message, a single message is compatible with JSON. The example for `produceMany` however, only has a string example.

Producing messages via produce with JSON works fine, for `produceMany`, you have to JSON.stringify the message value yourself. However, the code itself does say it would be running through `JSON.stringify`, which was not the case. https://github.com/upstash/upstash-kafka/blob/main/pkg/producer.ts#L39