### PR TITLE
add superjson to support stringifing more data structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const kafka = new Kafka({
 
 ```typescript
 const p = kafka.producer()
-const message = { hello: "world" } // Objects will get serialized using `JSON.stringify`
+const message = { hello: "world" } // Objects will get serialized using `superjson.stringify`
 const res = await p.produce("<my.topic>", message)
 const res = await p.produce("<my.topic>", message, {
   partition: 1,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "isomorphic-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0",
+    "superjson": "^1.12.3"
   },
   "browser": {
     "isomorphic-fetch": false

--- a/pkg/http.ts
+++ b/pkg/http.ts
@@ -1,5 +1,6 @@
 import "isomorphic-fetch"
 import { UpstashError } from "./error"
+import superjson from "superjson"
 
 export type Request = {
   path: string[]
@@ -50,7 +51,7 @@ export class HttpClient {
         const res = await fetch([this.baseUrl, ...req.path].join("/"), {
           method,
           headers,
-          body: JSON.stringify(req.body),
+          body: superjson.stringify(req.body),
         })
 
         const body = await res.json()

--- a/pkg/producer.ts
+++ b/pkg/producer.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from "./http"
+import superjson from "superjson"
 
 /**
  * Optional parameters for each produced message
@@ -65,7 +66,7 @@ export class Producer {
   ): Promise<ProduceResponse> {
     const request: ProduceRequest = {
       topic,
-      value: typeof message === "string" ? message : JSON.stringify(message),
+      value: typeof message === "string" ? message : superjson.stringify(message),
       ...opts,
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,12 +13,14 @@ specifiers:
   isomorphic-fetch: ^3.0.0
   jest: ^27.4.7
   prettier: ^2.5.1
+  superjson: ^1.12.3
   ts-jest: ^27.1.3
   tsup: ^5.11.11
   typescript: ^4.5.4
 
 dependencies:
   isomorphic-fetch: 3.0.0
+  superjson: 1.12.3
 
 devDependencies:
   '@jest/globals': 27.5.1
@@ -199,6 +201,8 @@ packages:
     resolution: {integrity: sha512-rL50YcEuHbbauAFAysNsJA4/f89fGTOBRNs9P81sniKnKAr4xULe5AecolcsKbi88xu0ByWYDj/S1AJ3FSFuSQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.2:
@@ -1268,6 +1272,13 @@ packages:
       safe-buffer: 5.1.2
     dev: true
 
+  /copy-anything/3.0.4:
+    resolution: {integrity: sha512-MaQ9FwzlZ/KLeVCLhzI3rZw0EhrIryfZa3AyT4agVybR0DjlkDHA8898lamLD6kfkf9MMn8D+zDAUR4+GxaymQ==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.9
+    dev: false
+
   /cross-spawn/7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -2152,6 +2163,11 @@ packages:
   /is-typedarray/1.0.0:
     resolution: {integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=}
     dev: true
+
+  /is-what/4.1.9:
+    resolution: {integrity: sha512-I3FU0rkVvwhgLLEs6iITwZ/JaLXe7tQcHyzupXky8jigt1vu4KM0UOqDr963j36JRvJ835EATVIm6MnGz/i1/g==}
+    engines: {node: '>=12.13'}
+    dev: false
 
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
@@ -3360,6 +3376,13 @@ packages:
       pirates: 4.0.5
       ts-interface-checker: 0.1.13
     dev: true
+
+  /superjson/1.12.3:
+    resolution: {integrity: sha512-0j+U70KUtP8+roVPbwfqkyQI7lBt7ETnuA7KXbTDX3mCKiD/4fXs2ldKSMdt0MCfpTwiMxo20yFU3vu6ewETpQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      copy-anything: 3.0.4
+    dev: false
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
+    "moduleResolution":"node",
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
Added https://github.com/blitz-js/superjson to support:
![image](https://github.com/upstash/upstash-kafka/assets/43915749/636eb5d5-742a-4654-8bf9-6b8a3ca9d4ac)

I have not tested this on an edge function yet